### PR TITLE
Add webhook exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Set the following environment variables in your chosen deployment:
 * `SLACK_CHANNEL`: the Slack channel to send messages to.
 * `SLACK_ICON_EMOJI`: the Slack emoji to use as the icon.
 * `GITHUB_URL`: the URL to the Github repository that Flux uses, used for Slack links.
+* `EXPORTER_TYPE` (optional): The type of exporter to use. (Choices: slack, webhook, Default: slack)
 
 And then apply the configuration:
 

--- a/cmd/fluxcloud.go
+++ b/cmd/fluxcloud.go
@@ -19,12 +19,34 @@ func main() {
 		log.Fatal(err)
 	}
 
-	exporter, err := exporters.NewWebhook(config)
-	if err != nil {
-		log.Fatal(err)
+	exporterType := config.Optional("Exporter_type", "slack")
+
+	var slackExporter *exporters.Slack
+	var webhookExporter *exporters.Webhook
+
+	var apiConfig apis.APIConfig
+
+	switch exporterType {
+	case "webhook":
+		log.Println("Using Webhook exporter")
+
+		webhookExporter, err = exporters.NewWebhook(config)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		apiConfig = apis.NewAPIConfig(formatter, webhookExporter, config)
+	default:
+		log.Println("Using Slack exporter")
+
+		slackExporter, err = exporters.NewSlack(config)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		apiConfig = apis.NewAPIConfig(formatter, slackExporter, config)
 	}
 
-	apiConfig := apis.NewAPIConfig(formatter, exporter, config)
 	apis.HandleWebsocket(apiConfig)
 	apis.HandleV6(apiConfig)
 	log.Fatal(apiConfig.Listen(":3031"))

--- a/cmd/fluxcloud.go
+++ b/cmd/fluxcloud.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"log"
+
 	"github.com/justinbarrick/fluxcloud/pkg/apis"
 	"github.com/justinbarrick/fluxcloud/pkg/config"
 	"github.com/justinbarrick/fluxcloud/pkg/exporters"
 	"github.com/justinbarrick/fluxcloud/pkg/formatters"
-	"log"
 )
 
 func main() {
@@ -18,7 +19,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	exporter, err := exporters.NewSlack(config)
+	exporter, err := exporters.NewWebhook(config)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/apis/v6.go
+++ b/pkg/apis/v6.go
@@ -30,8 +30,6 @@ func HandleV6(config APIConfig) error {
 			return
 		}
 
-		messages = append(messages, message)
-
 		err = config.Exporter.Send(config.Client, message)
 		if err != nil {
 			log.Print(err.Error())

--- a/pkg/apis/v6.go
+++ b/pkg/apis/v6.go
@@ -2,10 +2,11 @@ package apis
 
 import (
 	"bytes"
-	"github.com/justinbarrick/fluxcloud/pkg/utils"
 	"io/ioutil"
 	"log"
 	"net/http"
+
+	"github.com/justinbarrick/fluxcloud/pkg/utils"
 )
 
 // Handle Flux events
@@ -28,6 +29,8 @@ func HandleV6(config APIConfig) error {
 			w.WriteHeader(200)
 			return
 		}
+
+		messages = append(messages, message)
 
 		err = config.Exporter.Send(config.Client, message)
 		if err != nil {

--- a/pkg/exporters/webhook.go
+++ b/pkg/exporters/webhook.go
@@ -1,0 +1,65 @@
+package exporters
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/justinbarrick/fluxcloud/pkg/config"
+	"github.com/justinbarrick/fluxcloud/pkg/msg"
+)
+
+// The Webhook exporter sends Flux events to a Webhook channel via a webhook.
+type Webhook struct {
+	Url string
+}
+
+// Initialize a new Webhook instance
+func NewWebhook(config config.Config) (*Webhook, error) {
+	var err error
+	s := Webhook{}
+
+	s.Url, err = config.Required("Webhook_url")
+	if err != nil {
+		return nil, err
+	}
+
+	return &s, nil
+}
+
+// Send a WebhookMessage to Webhook
+func (s *Webhook) Send(client *http.Client, message msg.Message) error {
+	b := new(bytes.Buffer)
+	err := json.NewEncoder(b).Encode(message)
+	if err != nil {
+		log.Print("Could encode message to Webhook:", err)
+		return err
+	}
+
+	log.Print(string(b.Bytes()))
+	res, err := client.Post(s.Url, "application/json", b)
+	if err != nil {
+		log.Print("Could not post to Webhook:", err)
+		return err
+	}
+
+	if res.StatusCode != 200 {
+		log.Print("Could not post to Webhook, status: ", res.Status)
+		return errors.New(fmt.Sprintf("Could not post to Webhook, status: %d", res.StatusCode))
+	}
+
+	return nil
+}
+
+// Return the new line character for Webhook messages
+func (s *Webhook) NewLine() string {
+	return "\n"
+}
+
+// Return a formatted link for Webhook.
+func (s *Webhook) FormatLink(link string, name string) string {
+	return fmt.Sprintf("<%s|%s>", link, name)
+}


### PR DESCRIPTION
I have added a simple webhook exporter (mostly copy/paste from the existing Slack exporter) and added an option for choosing the exporter. 

I decided to do this after I saw #6 when searching for an option to push Flux Events somewhere else than to Slack.

If there is anything I would need to change, please tell me, I'm coming from a more "sysadmin-y" background and therefore writing code is not something I do daily.