### PR TITLE
RFC: Add formatter templates

### DIFF
--- a/pkg/formatters/default.go
+++ b/pkg/formatters/default.go
@@ -1,17 +1,46 @@
 package formatters
 
 import (
-	"fmt"
+	"bytes"
+	"html/template"
+	"log"
+	"strings"
+	"time"
+
 	"github.com/justinbarrick/fluxcloud/pkg/config"
 	"github.com/justinbarrick/fluxcloud/pkg/exporters"
 	"github.com/justinbarrick/fluxcloud/pkg/msg"
+	"github.com/weaveworks/flux"
 	fluxevent "github.com/weaveworks/flux/event"
+)
+
+const (
+	titleTemplate = `Applied flux changes to cluster`
+	bodyTemplate  = `
+Event: {{ .EventString }}
+{{ if and (ne .EventType "commit") (gt (len .Commits) 0) }}Commits:
+{{ range .Commits }}
+* {{ call $.FormatLink (print $.VCSLink "/commit/" .Revision) (printf "%.7s" .Revision) }}: {{ .Message }}
+{{end}}{{end}}
+{{ if (gt (len .EventServiceIDs) 0) }}Resources updated:
+{{ range .EventServiceIDs }}
+* {{ . }}
+{{ end }}{{ end }}
+{{ if gt (len .Errors) 0 }}Errors:
+{{ range .Errors }}
+Resource {{ .ID }}, file: {{ .Path }}:
+
+> {{ call $.FormatError .Error }}
+{{ end }}{{ end }}
+`
 )
 
 // The default formatter formats a message for a chat webhook
 type DefaultFormatter struct {
-	config  config.Config
-	vcsLink string
+	config        config.Config
+	vcsLink       string
+	bodyTemplate  string
+	titleTemplate string
 }
 
 // Create a DefaultFormatter
@@ -22,69 +51,111 @@ func NewDefaultFormatter(config config.Config) (*DefaultFormatter, error) {
 	}
 
 	return &DefaultFormatter{
-		config:  config,
-		vcsLink: vcsLink,
+		config:        config,
+		vcsLink:       vcsLink,
+		bodyTemplate:  config.Optional("body_template", bodyTemplate),
+		titleTemplate: config.Optional("title_template", titleTemplate),
 	}, nil
 }
 
 // Format plaintext message for an exporter for Flux event
 func (d DefaultFormatter) FormatEvent(event fluxevent.Event, exporter exporters.Exporter) msg.Message {
-	newLine := exporter.NewLine()
-	body := fmt.Sprintf("Event: %s%s", event.String(), newLine)
-	errorBody := ""
-	commit_id := ""
-
 	if len(event.ServiceIDs) == 0 {
 		return msg.Message{}
 	}
 
-	titleLink := d.vcsLink
-
-	switch event.Type {
-	case fluxevent.EventSync:
-		metadata := event.Metadata.(*fluxevent.SyncEventMetadata)
-		commit_id = metadata.Commits[0].Revision
-
-		body += fmt.Sprintf("Commits: %s", newLine)
-		for _, commit := range metadata.Commits {
-			vcsLinkWithCommit := d.vcsLink + "/commit/" + commit.Revision
-			link := exporter.FormatLink(vcsLinkWithCommit, commit.Revision[:7])
-			body += fmt.Sprintf("%s* %s: %s", newLine, link, commit.Message)
-		}
-
-		body += newLine
-
-		if len(metadata.Errors) > 0 {
-			errorBody += "Errors:\n"
-
-			for _, err := range metadata.Errors {
-				errorBody = fmt.Sprintf("%s\nResource %s, file: %s:\n\n> %s\n", errorBody, err.ID, err.Path, err.Error)
-			}
-		}
-	case fluxevent.EventCommit:
-		metadata := event.Metadata.(*fluxevent.CommitEventMetadata)
-		commit_id = metadata.Revision
-	default:
+	values := struct {
+		VCSLink         string
+		EventID         fluxevent.EventID
+		EventServiceIDs []flux.ResourceID
+		EventType       template.HTML
+		EventStartedAt  time.Time
+		EventEndedAt    time.Time
+		EventLogLevel   template.HTML
+		EventMessage    template.HTML
+		EventString     template.HTML
+		Commits         []fluxevent.Commit
+		Errors          []fluxevent.ResourceError
+		FormatError     func(string) template.HTML
+		FormatLink      func(string, string) template.HTML
+	}{
+		VCSLink:         d.vcsLink,
+		EventID:         event.ID,
+		EventServiceIDs: event.ServiceIDs,
+		EventType:       template.HTML(event.Type),
+		EventStartedAt:  event.StartedAt,
+		EventEndedAt:    event.EndedAt,
+		EventLogLevel:   template.HTML(event.LogLevel),
+		EventMessage:    template.HTML(event.Message),
+		EventString:     template.HTML(event.String()),
+		Commits:         getCommits(event.Metadata),
+		Errors:          getErrors(event.Metadata),
+		FormatError: func(text string) template.HTML {
+			return template.HTML(text)
+		},
+		FormatLink: func(link, text string) template.HTML {
+			return template.HTML(exporter.FormatLink(link, text))
+		},
 	}
 
-	body += fmt.Sprintf("%sResources updated:%s", newLine, newLine)
-	for _, serviceId := range event.ServiceIDStrings() {
-		body += fmt.Sprintf("%s* %s", newLine, serviceId)
-	}
+	nl := exporter.NewLine()
 
-	if len(errorBody) != 0 {
-		body += fmt.Sprintf("\n\n%s", errorBody)
-	}
-
-	if commit_id != "" {
-		titleLink = d.vcsLink + "/commit/" + commit_id
-	}
-
-	return msg.Message{
-		TitleLink: titleLink,
-		Title:     "Applied flux changes to cluster",
-		Body:      body,
+	message := msg.Message{
+		TitleLink: d.vcsLink,
+		Title:     parseTemplate(d.titleTemplate, values, nl),
+		Body:      parseTemplate(d.bodyTemplate, values, nl),
 		Type:      event.Type,
 		Event:     event,
+	}
+
+	if message.Title == "" || message.Body == "" {
+		return msg.Message{}
+	}
+
+	commits := getCommits(event.Metadata)
+	if len(commits) > 0 {
+		message.TitleLink = d.vcsLink + "/commit/" + commits[0].Revision
+	}
+
+	return message
+}
+
+func parseTemplate(tpl string, values interface{}, nl string) string {
+	bodyBytes := &bytes.Buffer{}
+	bodyTpl := template.New("")
+	bodyTpl, _ = bodyTpl.Parse(tpl)
+	if err := bodyTpl.Execute(bodyBytes, values); err != nil {
+		log.Println("could not execute body template:", err)
+		return ""
+	}
+
+	body := bodyBytes.String()
+	body = strings.TrimSpace(body)
+	body = strings.Replace(body, "\n", nl, -1)
+
+	return body
+}
+
+func getCommits(meta fluxevent.EventMetadata) []fluxevent.Commit {
+	switch v := meta.(type) {
+	case *fluxevent.CommitEventMetadata:
+		return []fluxevent.Commit{
+			fluxevent.Commit{
+				Revision: v.Revision,
+			},
+		}
+	case *fluxevent.SyncEventMetadata:
+		return v.Commits
+	default:
+		return []fluxevent.Commit{}
+	}
+}
+
+func getErrors(meta fluxevent.EventMetadata) []fluxevent.ResourceError {
+	switch v := meta.(type) {
+	case *fluxevent.SyncEventMetadata:
+		return v.Errors
+	default:
+		return []fluxevent.ResourceError{}
 	}
 }


### PR DESCRIPTION
Current version of fluxcloud is kinda spammy and spits out more information than we actually care about (at least for the moment). Additionally anyone who wanted a custom formatter would have to have their own fork with their formatter implementation and maintain it. This is an alternative approach to the default formatter that uses a go template to render the flux events. 

### Changelog

* Refactor default formatter to use go templates for both message title and message body
  The values that can be used right now are the following:
  ```golang
	values := &tplValues{
		VCSLink:            d.vcsLink,
		EventID:            event.ID,
		EventServiceIDs:    event.ServiceIDs,
		EventChangedImages: getChangedImages(event.Metadata),
		EventResult:        getResult(event.Metadata),
		EventType:          event.Type,
		EventStartedAt:     event.StartedAt,
		EventEndedAt:       event.EndedAt,
		EventLogLevel:      event.LogLevel,
		EventMessage:       event.Message,
		EventString:        event.String(),
		Commits:            getCommits(event.Metadata),
		Errors:             getErrors(event.Metadata),
		FormatLink: func(link, text string) string {
			return exporter.FormatLink(link, text)
		},
	}
  ```
* Add default template for title and body that match the current output
* Add option to overwrite the templates using the `TITLE_TEMPLATE` and `BODY_TEMPLATE`
* Add helper functions for templates (`trim`, `truncate`, `replace`, `contains`)

### Example

```yaml
        - name: TITLE_TEMPLATE
          value: |2-
            {{ if eq .EventType "commit" }}Applying changes from commit{{ end }}
            {{ if eq .EventType "autorelease" }}Auto releasing resources{{ end }}
        - name: BODY_TEMPLATE
          value: >2-
            {{ if or (eq .EventType "autorelease") (eq .EventType "commit") }}
            {{ range $resourceName, $resourceResult := .EventResult }}
            {{ if eq $resourceResult.Status "success" }}
            {{ range $resourceResult.PerContainer }}
            {{ if not (eq .Current.String .Target.String) }}
            * Updating *{{ replace $resourceName.String ":fluxhelmrelease" "" }}* to *{{ .Current.Tag }}*

            {{ end }}
            {{ end }}
            {{ end }}
            {{ if eq $resourceResult.Status "error" }}
            *Error updating {{ replace $resourceName.String ":fluxhelmrelease" "" }}*
            
            *Error message*: {{ $resourceResult.Error }}
            {{ end }}
            {{ end }}
            {{ end }}
```

Results in something like 
![screenshot 2018-10-03 15 32 25](https://user-images.githubusercontent.com/88447/46417441-94da9000-c721-11e8-8fee-64e015d91415.png)
