### PR TITLE
Add support for sending notifications to multiple Slack channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,32 @@ one already, feel free to contribute one by implementing the [exporter interface
 ## Slack
 
 The default exporter to use is Slack. To use the Slack exporter, set the `SLACK_URL`,
-`SLACK_USERNAME`, and `SLACK_CHANNEL` environment variables to use. You can also
-optionally set the `EXPORTER_TYPE` to "slack".
+`SLACK_USERNAME`, and `SLACK_CHANNEL` or `SLACK_CHANNEL_PATH` environment variables to
+use. You can also optionally set the `EXPORTER_TYPE` to "slack".
+
+### Sending notifications to multiple channels
+
+If sending notifications to only one channel is unsufficient for your use case you can
+configure fluxcloud to send them to multiple channels based upon the namespace(s) from
+the created and/or updated resources. This is done by providing the path to a JSON config
+using the `SLACK_CHANNEL_PATH` environment variable.
+
+The formatting of the JSON should look like this:
+
+```json
+[
+    {
+        "channel": "#team",
+        "namespace": "team"
+    },
+    {
+        "channel": "#all-namespaces",
+        "namespace": "*"
+    }
+]
+```
+
+`"namespace": "*"` will skip filtering and send all notifications to the channel.
 
 ## Webhooks
 

--- a/examples/flux-deployment-sidecar.yaml
+++ b/examples/flux-deployment-sidecar.yaml
@@ -73,3 +73,33 @@ spec:
           value: ":heart:"
         - name: GITHUB_URL
           value: "https://github.com/justinbarrick/fluxcloud/"
+# Uncomment the lines below and update the ConfigMap to enable
+# sending notifications to multiple Slack channels based upon
+# the namespace from the created and/or updated resources.
+#         - name: SLACK_CHANNEL_PATH
+#           value: "/etc/config/channels.json"
+#         volumeMounts:
+#         - name: slack-config
+#           mountPath: /etc/config/
+#           readOnly: true
+#       volumes:
+#       - name: slack-config
+#         configMap:
+#           name: fluxcloud-channels
+# ---
+# apiVersion: v1
+# kind: ConfigMap
+# metadata:
+#   name: fluxcloud-slack
+# data:
+#   channels.json: |
+#     [
+#       {
+#         "namespace": "*",
+#         "channel": "#general"
+#       },
+#       {
+#         "namespace": "team",
+#         "channel": "#team"
+#       }
+#     ]

--- a/examples/fluxcloud.yaml
+++ b/examples/fluxcloud.yaml
@@ -41,3 +41,33 @@ spec:
           value: ":heart:"
         - name: GITHUB_URL
           value: "https://github.com/justinbarrick/fluxcloud/"
+# Uncomment the lines below and update the ConfigMap to enable
+# sending notifications to multiple Slack channels based upon
+# the namespace from the created and/or updated resources.
+#         - name: SLACK_CHANNEL_PATH
+#           value: "/etc/config/channels.json"
+#         volumeMounts:
+#         - name: slack-config
+#           mountPath: /etc/config/
+#           readOnly: true
+#       volumes:
+#       - name: slack-config
+#         configMap:
+#           name: fluxcloud-channels
+# ---
+# apiVersion: v1
+# kind: ConfigMap
+# metadata:
+#   name: fluxcloud-slack
+# data:
+#   channels.json: |
+#     [
+#       {
+#         "namespace": "*",
+#         "channel": "#general"
+#       },
+#       {
+#         "namespace": "team",
+#         "channel": "#team"
+#       }
+#     ]

--- a/pkg/apis/integration_test.go
+++ b/pkg/apis/integration_test.go
@@ -3,14 +3,15 @@ package apis
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/justinbarrick/fluxcloud/pkg/config"
 	"github.com/justinbarrick/fluxcloud/pkg/exporters"
 	"github.com/justinbarrick/fluxcloud/pkg/formatters"
 	"github.com/justinbarrick/fluxcloud/pkg/utils/test"
 	"github.com/stretchr/testify/assert"
-	"net/http"
-	"net/http/httptest"
-	"testing"
 )
 
 func TestSlackIntegrationTest(t *testing.T) {
@@ -28,7 +29,7 @@ func TestSlackIntegrationTest(t *testing.T) {
 		sent := exporters.SlackMessage{}
 		json.NewDecoder(r.Body).Decode(&sent)
 		formatted := exporter.NewSlackMessage(formatter.FormatEvent(event, exporter))
-		assert.Equal(t, sent, formatted)
+		assert.Equal(t, sent, formatted[0])
 		reqCount += 1
 	}))
 	defer ts.Close()

--- a/pkg/exporters/slack.go
+++ b/pkg/exporters/slack.go
@@ -3,19 +3,21 @@ package exporters
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"github.com/justinbarrick/fluxcloud/pkg/config"
-	"github.com/justinbarrick/fluxcloud/pkg/msg"
+	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+
+	"github.com/justinbarrick/fluxcloud/pkg/config"
+	"github.com/justinbarrick/fluxcloud/pkg/msg"
 )
 
 // The Slack exporter sends Flux events to a Slack channel via a webhook.
 type Slack struct {
 	Url       string
 	Username  string
-	Channel   string
+	Channels  []SlackChannel
 	IconEmoji string
 }
 
@@ -35,6 +37,12 @@ type SlackAttachment struct {
 	Text      string `json:"text"`
 }
 
+// Represents a slack channel and the Kubernetes namespace linked to it
+type SlackChannel struct {
+	Channel   string `json:"channel"`
+	Namespace string `json:"namespace"`
+}
+
 // Initialize a new Slack instance
 func NewSlack(config config.Config) (*Slack, error) {
 	var err error
@@ -45,10 +53,21 @@ func NewSlack(config config.Config) (*Slack, error) {
 		return nil, err
 	}
 
-	s.Channel, err = config.Required("slack_channel")
-	if err != nil {
-		return nil, err
+	channels := config.Optional("slack_channel_path", "")
+	if channels == "" {
+		channel, err := config.Required("slack_channel")
+		if err != nil {
+			return nil, err
+		}
+		s.Channels = append(s.Channels, SlackChannel{channel, "*"})
 	}
+	if channels != "" {
+		err := s.unmarshallChannels(channels)
+		if err != nil {
+			return nil, err
+		}
+	}
+	log.Println(s.Channels)
 
 	s.Username = config.Optional("slack_username", "Flux Deployer")
 	s.IconEmoji = config.Optional("slack_icon_emoji", ":star-struck:")
@@ -58,23 +77,26 @@ func NewSlack(config config.Config) (*Slack, error) {
 
 // Send a SlackMessage to Slack
 func (s *Slack) Send(client *http.Client, message msg.Message) error {
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(s.NewSlackMessage(message))
-	if err != nil {
-		log.Print("Could encode message to slack:", err)
-		return err
-	}
+	for _, slackMessage := range s.NewSlackMessage(message) {
+		fmt.Println(slackMessage)
+		b := new(bytes.Buffer)
+		err := json.NewEncoder(b).Encode(slackMessage)
+		if err != nil {
+			log.Print("Could encode message to slack:", err)
+			return err
+		}
 
-	log.Print(string(b.Bytes()))
-	res, err := client.Post(s.Url, "application/json", b)
-	if err != nil {
-		log.Print("Could not post to slack:", err)
-		return err
-	}
+		log.Print(string(b.Bytes()))
+		res, err := client.Post(s.Url, "application/json", b)
+		if err != nil {
+			log.Print("Could not post to slack:", err)
+			return err
+		}
 
-	if res.StatusCode != 200 {
-		log.Print("Could not post to slack, status: ", res.Status)
-		return errors.New(fmt.Sprintf("Could not post to slack, status: %d", res.StatusCode))
+		if res.StatusCode != 200 {
+			log.Print("Could not post to slack, status: ", res.Status)
+			return fmt.Errorf("Could not post to slack, status: %d", res.StatusCode)
+		}
 	}
 
 	return nil
@@ -90,24 +112,70 @@ func (s *Slack) FormatLink(link string, name string) string {
 	return fmt.Sprintf("<%s|%s>", link, name)
 }
 
-// Convert a flux event into a Slack message
-func (s *Slack) NewSlackMessage(message msg.Message) SlackMessage {
-	return SlackMessage{
-		Channel:   s.Channel,
-		IconEmoji: s.IconEmoji,
-		Username:  s.Username,
-		Attachments: []SlackAttachment{
-			SlackAttachment{
-				Color:     "#4286f4",
-				TitleLink: message.TitleLink,
-				Title:     message.Title,
-				Text:      message.Body,
+// Convert a flux event into a Slack message(s)
+func (s *Slack) NewSlackMessage(message msg.Message) []SlackMessage {
+	var messages []SlackMessage
+
+	for _, channel := range s.determineChannels(message) {
+		slackMessage := SlackMessage{
+			Channel:   channel,
+			IconEmoji: s.IconEmoji,
+			Username:  s.Username,
+			Attachments: []SlackAttachment{
+				SlackAttachment{
+					Color:     "#4286f4",
+					TitleLink: message.TitleLink,
+					Title:     message.Title,
+					Text:      message.Body,
+				},
 			},
-		},
+		}
+		messages = append(messages, slackMessage)
 	}
+
+	return messages
 }
 
 // Return the name of the exporter.
 func (s *Slack) Name() string {
 	return "Slack"
+}
+
+func (s *Slack) unmarshallChannels(configPath string) error {
+	f, err := os.Open(configPath)
+	defer f.Close()
+	if err != nil {
+		return err
+	}
+
+	b, _ := ioutil.ReadAll(f)
+	if err := json.Unmarshal(b, &s.Channels); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Match namespaces from service IDs to Slack channels.
+func (s *Slack) determineChannels(message msg.Message) []string {
+	var channels []string
+	for _, serviceID := range message.Event.ServiceIDs {
+		ns, _, _ := serviceID.Components()
+
+		for _, ch := range s.Channels {
+			if ch.Namespace == "*" || ch.Namespace == ns {
+				channels = appendIfMissing(channels, ch.Channel)
+			}
+		}
+	}
+	return channels
+}
+
+func appendIfMissing(slice []string, s string) []string {
+	for _, v := range slice {
+		if v == s {
+			return slice
+		}
+	}
+	return append(slice, s)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,8 +2,9 @@ package utils
 
 import (
 	"encoding/json"
-	fluxevent "github.com/weaveworks/flux/event"
 	"io"
+
+	fluxevent "github.com/weaveworks/flux/event"
 )
 
 // Parse a flux event from Json into a flux Event struct.


### PR DESCRIPTION
This PR adds support for sending notifications to multiple Slack channels based upon the namespace(s) of created and/or updated resources.

To enable this feature one should set the `SLACK_CHANNEL_PATH` environment to a JSON file containing a list of channels/namespaces.

```json
[
  {
    "channel": "#team",
    "namespace": "team"
  },
  {
    "channel": "#stream",
    "namespace": "*"
  }
]
```