### PR TITLE
updated flux vendor package to 1.6.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,25 +2,32 @@
 
 
 [[projects]]
+  digest = "1:a26f8da48b22e6176c1c6a2459904bb30bd0c49ada04b2963c2c3a203e81a620"
   name = "github.com/Masterminds/semver"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "c7af12943936e8c39859482e61f0574c2fd7fc75"
   version = "v1.4.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:707ebe952a8b3d00b343c01536c79c73771d100f63ec6babeaed5c79e2b8a8dd"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "NUT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "NUT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:f8b9eb707f84a5f01f1537f2086962590855bb63a616eb35c02c437f60431018"
   name = "github.com/docker/distribution"
   packages = [
     ".",
@@ -38,169 +45,217 @@
     "registry/client/auth/challenge",
     "registry/client/transport",
     "registry/storage/cache",
-    "registry/storage/cache/memory"
+    "registry/storage/cache/memory",
   ]
+  pruneopts = "NUT"
   revision = "749f6afb4572201e3c37325d0ffedb6f32be8950"
 
 [[projects]]
   branch = "master"
+  digest = "1:8e5e04894d9d663ac464d6e73803d602f85fe679ec5a54de35378b5d073efd64"
   name = "github.com/docker/go-metrics"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "399ea8c73916000c64c2c76e8da00ca82f8387ab"
 
 [[projects]]
   branch = "master"
+  digest = "1:ce43438a8204a4259b4461153a392bc3e504bef7e4785a8192344f002c7bd935"
   name = "github.com/docker/libtrust"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "aabc10ec26b754e797f9028f4589c5b7bd90dc20"
 
 [[projects]]
+  digest = "1:43c42a6146a207a5693f039425916d279ddbf7d96df526252cd9d3b4ba7aa274"
   name = "github.com/go-kit/kit"
   packages = [
     "log",
     "metrics",
     "metrics/internal/lv",
-    "metrics/prometheus"
+    "metrics/prometheus",
   ]
+  pruneopts = "NUT"
   revision = "ca4112baa34cb55091301bdc13b1420a122b1b9e"
   version = "v0.7.0"
 
 [[projects]]
+  digest = "1:341a7df38da99fe91ed40e4008c13cc5d02dcc98ed1a094360cb7d5df26d6d26"
   name = "github.com/go-logfmt/logfmt"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:a1efdbc2762667c8a41cbf02b19a0549c846bf2c1d08cad4f445e3344089f1f0"
   name = "github.com/go-stack/stack"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
   version = "v1.7.0"
 
 [[projects]]
+  digest = "1:15042ad3498153684d09f393bbaec6b216c8eec6d61f63dff711de7d64ed8861"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = "NUT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:c01767916c59f084bb7c41a7d5877c0f3099b1595cfa066e84ec6ad6b084dd89"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:bf5cf1d53d703332e9bd8984c69784645b73a938317bf5ace9aadf20ac49379a"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
   version = "v1.6.2"
 
 [[projects]]
+  digest = "1:3b708ebf63bfa9ba3313bedb8526bc0bb284e51474e65e958481476a9d4a12aa"
   name = "github.com/gorilla/websocket"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:f91bb67d051a94cf6ab2cf07eee0550432afc31655838d42cdec258db4b348f0"
   name = "github.com/kr/logfmt"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
+  digest = "1:5985ef4caf91ece5d54817c11ea25f182697534f8ae6521eadcd628c142ac4b6"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = "NUT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:e0cc8395ea893c898ff5eb0850f4d9851c1f57c78c232304a026379a47a552d0"
   name = "github.com/opencontainers/go-digest"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
   version = "v1.0.0-rc1"
 
 [[projects]]
+  digest = "1:5cf3f025cbee5951a4ee961de067c8a89fc95a5adabead774f82822efabab121"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:8a1eda1fe08a100c33c8ca65009a7e28571df212dca67719bce49b56920831b5"
   name = "github.com/pkg/term"
   packages = [
     ".",
-    "termios"
+    "termios",
   ]
+  pruneopts = "NUT"
   revision = "bffc007b7fd5a70e20e28f5b7649bb84671ef436"
 
 [[projects]]
+  digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = "NUT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:d41f9b875859399cd400b96ba7e15f299925c9c7a71b24e6fa92b0ea4c761b91"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
-    "prometheus/promhttp"
+    "prometheus/promhttp",
   ]
+  pruneopts = "NUT"
   revision = "d6a9817c4afc94d51115e4a30d449056a3fbf547"
 
 [[projects]]
   branch = "master"
+  digest = "1:32d10bdfa8f09ecf13598324dba86ab891f11db3c538b6a34d1c3b5b99d7c36b"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = "NUT"
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
+  digest = "1:768b555b86742de2f28beb37f1dedce9a75f91f871d75b5717c96399c1a78c08"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = "NUT"
   revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
 
 [[projects]]
   branch = "master"
+  digest = "1:7f62a585f73007e8b6531a8a407349f43809495231c41fff6886d6ce12f870a2"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = "NUT"
   revision = "40f013a808ec4fa79def444a1a56de4d1727efcb"
 
 [[projects]]
+  digest = "1:cb24eec7a9478395847671abfbea162885f0be9c7ff6ef20b699dc20804ae1a4"
   name = "github.com/ryanuber/go-glob"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "572520ed46dbddaed19ea3d9541bdd0494163693"
   version = "v0.1"
 
 [[projects]]
+  digest = "1:6989062eb7ccf25cf38bf4fe3dba097ee209f896cda42cefdca3927047bef7b6"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
   version = "v1.0.5"
 
 [[projects]]
+  digest = "1:15e5c398fbd9d2c439b635a08ac161b13d04f0c2aa587fe256b65dc0c3efe8b7"
   name = "github.com/spf13/pflag"
   packages = ["."]
+  pruneopts = "NUT"
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:bacb8b590716ab7c33f2277240972c9582d389593ee8d66fc10074e0508b8126"
   name = "github.com/stretchr/testify"
   packages = ["assert"]
+  pruneopts = "NUT"
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
 
 [[projects]]
+  digest = "1:1a9ee25d11d3b270a9a82418357b683152f579682e4f39f9dd2cdbd41f7ea651"
   name = "github.com/weaveworks/flux"
   packages = [
     ".",
@@ -214,41 +269,56 @@
     "registry/middleware",
     "resource",
     "ssh",
-    "update"
+    "update",
   ]
-  revision = "78b82e5bd2e0182e8c6ee5d5b983226184f75cd5"
-  version = "1.5.0"
+  pruneopts = "NUT"
+  revision = "185dfdf5a317d8ed2042f6afe2d6b94950282aff"
+  version = "1.7.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:3f3a05ae0b95893d90b9b3b5afdb79a9b3d96e4e36e099d841ae602e4aca0da8"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
+  pruneopts = "NUT"
   revision = "a49355c7e3f8fe157a85be2f77e6e269a0f89602"
 
 [[projects]]
   branch = "master"
+  digest = "1:76ee51c3f468493aff39dbacc401e8831fbb765104cbf613b89bef01cf4bad70"
   name = "golang.org/x/net"
   packages = ["context"]
+  pruneopts = "NUT"
   revision = "ed29d75add3d7c4bf7ca65aac0c6df3d1420216f"
 
 [[projects]]
   branch = "master"
+  digest = "1:baa3044d8a33b3cd690c16fd555c5a543f980206cd1a696f7902307f57f911ec"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
+  pruneopts = "NUT"
   revision = "7138fd3d9dc8335c567ca206f4333fb75eb05d56"
 
 [[projects]]
   branch = "master"
+  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "golang.org/x/time"
   packages = ["rate"]
+  pruneopts = "NUT"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f2f9cec540d420310ea0169c7a6579e1cad9273eb03c282c86ddbb6aa44869bd"
+  input-imports = [
+    "github.com/gorilla/websocket",
+    "github.com/stretchr/testify/assert",
+    "github.com/weaveworks/flux",
+    "github.com/weaveworks/flux/event",
+    "github.com/weaveworks/flux/update",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/weaveworks/flux"
-  version = "1.5.0"
+  version = "1.6.0"
 
 [prune]
   go-tests = true

--- a/vendor/github.com/weaveworks/flux/cluster/manifests.go
+++ b/vendor/github.com/weaveworks/flux/cluster/manifests.go
@@ -26,24 +26,22 @@ func ErrResourceNotFound(name string) error {
 type Manifests interface {
 	// Update the image in a manifest's bytes to that given
 	UpdateImage(def []byte, resourceID flux.ResourceID, container string, newImageID image.Ref) ([]byte, error)
-	// Load all the resource manifests under the path given. `baseDir`
-	// is used to relativise the paths, which are supplied as absolute
-	// paths to directories or files; at least one path must be
-	// supplied.
-	LoadManifests(baseDir, first string, rest ...string) (map[string]resource.Resource, error)
+	// Load all the resource manifests under the paths
+	// given. `baseDir` is used to relativise the paths, which are
+	// supplied as absolute paths to directories or files; at least
+	// one path should be supplied, even if it is the same as `baseDir`.
+	LoadManifests(baseDir string, paths []string) (map[string]resource.Resource, error)
 	// Parse the manifests given in an exported blob
 	ParseManifests([]byte) (map[string]resource.Resource, error)
 	// UpdatePolicies modifies a manifest to apply the policy update specified
 	UpdatePolicies([]byte, flux.ResourceID, policy.Update) ([]byte, error)
-	// ServicesWithPolicies returns all services with their associated policies
-	ServicesWithPolicies(path string) (policy.ResourceMap, error)
 }
 
 // UpdateManifest looks for the manifest for the identified resource,
 // reads its contents, applies f(contents), and writes the results
 // back to the file.
-func UpdateManifest(m Manifests, root string, id flux.ResourceID, f func(manifest []byte) ([]byte, error)) error {
-	resources, err := m.LoadManifests(root, root)
+func UpdateManifest(m Manifests, root string, paths []string, id flux.ResourceID, f func(manifest []byte) ([]byte, error)) error {
+	resources, err := m.LoadManifests(root, paths)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/weaveworks/flux/cluster/mock.go
+++ b/vendor/github.com/weaveworks/flux/cluster/mock.go
@@ -10,18 +10,17 @@ import (
 
 // Doubles as a cluster.Cluster and cluster.Manifests implementation
 type Mock struct {
-	AllServicesFunc          func(maybeNamespace string) ([]Controller, error)
-	SomeServicesFunc         func([]flux.ResourceID) ([]Controller, error)
-	PingFunc                 func() error
-	ExportFunc               func() ([]byte, error)
-	SyncFunc                 func(SyncDef) error
-	PublicSSHKeyFunc         func(regenerate bool) (ssh.PublicKey, error)
-	UpdateImageFunc          func(def []byte, id flux.ResourceID, container string, newImageID image.Ref) ([]byte, error)
-	LoadManifestsFunc        func(base, first string, rest ...string) (map[string]resource.Resource, error)
-	ParseManifestsFunc       func([]byte) (map[string]resource.Resource, error)
-	UpdateManifestFunc       func(path, resourceID string, f func(def []byte) ([]byte, error)) error
-	UpdatePoliciesFunc       func([]byte, flux.ResourceID, policy.Update) ([]byte, error)
-	ServicesWithPoliciesFunc func(path string) (policy.ResourceMap, error)
+	AllServicesFunc    func(maybeNamespace string) ([]Controller, error)
+	SomeServicesFunc   func([]flux.ResourceID) ([]Controller, error)
+	PingFunc           func() error
+	ExportFunc         func() ([]byte, error)
+	SyncFunc           func(SyncDef) error
+	PublicSSHKeyFunc   func(regenerate bool) (ssh.PublicKey, error)
+	UpdateImageFunc    func(def []byte, id flux.ResourceID, container string, newImageID image.Ref) ([]byte, error)
+	LoadManifestsFunc  func(base string, paths []string) (map[string]resource.Resource, error)
+	ParseManifestsFunc func([]byte) (map[string]resource.Resource, error)
+	UpdateManifestFunc func(path, resourceID string, f func(def []byte) ([]byte, error)) error
+	UpdatePoliciesFunc func([]byte, flux.ResourceID, policy.Update) ([]byte, error)
 }
 
 func (m *Mock) AllControllers(maybeNamespace string) ([]Controller, error) {
@@ -52,8 +51,8 @@ func (m *Mock) UpdateImage(def []byte, id flux.ResourceID, container string, new
 	return m.UpdateImageFunc(def, id, container, newImageID)
 }
 
-func (m *Mock) LoadManifests(base, first string, rest ...string) (map[string]resource.Resource, error) {
-	return m.LoadManifestsFunc(base, first, rest...)
+func (m *Mock) LoadManifests(base string, paths []string) (map[string]resource.Resource, error) {
+	return m.LoadManifestsFunc(base, paths)
 }
 
 func (m *Mock) ParseManifests(def []byte) (map[string]resource.Resource, error) {
@@ -66,8 +65,4 @@ func (m *Mock) UpdateManifest(path string, resourceID string, f func(def []byte)
 
 func (m *Mock) UpdatePolicies(def []byte, id flux.ResourceID, p policy.Update) ([]byte, error) {
 	return m.UpdatePoliciesFunc(def, id, p)
-}
-
-func (m *Mock) ServicesWithPolicies(path string) (policy.ResourceMap, error) {
-	return m.ServicesWithPoliciesFunc(path)
 }

--- a/vendor/github.com/weaveworks/flux/flux.go
+++ b/vendor/github.com/weaveworks/flux/flux.go
@@ -13,9 +13,14 @@ import (
 var (
 	ErrInvalidServiceID = errors.New("invalid service ID")
 
-	LegacyServiceIDRegexp       = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)$")
-	ResourceIDRegexp            = regexp.MustCompile("^([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.-]+)$")
-	UnqualifiedResourceIDRegexp = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.-]+)$")
+	LegacyServiceIDRegexp = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)$")
+	// The namespace and name commponents are (apparently
+	// non-normatively) defined in
+	// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/identifiers.md
+	// In practice, more punctuation is used than allowed there;
+	// specifically, people use underscores as well as dashes and dots, and in names, colons.
+	ResourceIDRegexp            = regexp.MustCompile("^([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.:-]+)$")
+	UnqualifiedResourceIDRegexp = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.:-]+)$")
 )
 
 // ResourceID is an opaque type which uniquely identifies a resource in an

--- a/vendor/github.com/weaveworks/flux/policy/policy.go
+++ b/vendor/github.com/weaveworks/flux/policy/policy.go
@@ -36,12 +36,8 @@ func Tag(policy Policy) bool {
 	return strings.HasPrefix(string(policy), "tag.")
 }
 
-func GetTagPattern(services ResourceMap, service flux.ResourceID, container string) Pattern {
-	if services == nil {
-		return PatternAll
-	}
-	policies, ok := services[service]
-	if !ok {
+func GetTagPattern(policies Set, container string) Pattern {
+	if policies == nil {
 		return PatternAll
 	}
 	pattern, ok := policies.Get(TagPrefix(container))
@@ -140,39 +136,4 @@ func (s Set) ToStringMap() map[string]string {
 		m[string(p)] = v
 	}
 	return m
-}
-
-type ResourceMap map[flux.ResourceID]Set
-
-func (s ResourceMap) ToSlice() []flux.ResourceID {
-	slice := []flux.ResourceID{}
-	for service, _ := range s {
-		slice = append(slice, service)
-	}
-	return slice
-}
-
-func (s ResourceMap) Contains(id flux.ResourceID) bool {
-	_, ok := s[id]
-	return ok
-}
-
-func (s ResourceMap) Without(other ResourceMap) ResourceMap {
-	newMap := ResourceMap{}
-	for k, v := range s {
-		if !other.Contains(k) {
-			newMap[k] = v
-		}
-	}
-	return newMap
-}
-
-func (s ResourceMap) OnlyWithPolicy(p Policy) ResourceMap {
-	newMap := ResourceMap{}
-	for k, v := range s {
-		if v.Has(p) {
-			newMap[k] = v
-		}
-	}
-	return newMap
 }

--- a/vendor/github.com/weaveworks/flux/update/filter.go
+++ b/vendor/github.com/weaveworks/flux/update/filter.go
@@ -3,6 +3,7 @@ package update
 import (
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/policy"
 )
 
 const (
@@ -77,16 +78,13 @@ func (f *IncludeFilter) Filter(u ControllerUpdate) ControllerResult {
 }
 
 type LockedFilter struct {
-	IDs []flux.ResourceID
 }
 
 func (f *LockedFilter) Filter(u ControllerUpdate) ControllerResult {
-	for _, id := range f.IDs {
-		if u.ResourceID == id {
-			return ControllerResult{
-				Status: ReleaseStatusSkipped,
-				Error:  Locked,
-			}
+	if u.Resource.Policy().Has(policy.Locked) {
+		return ControllerResult{
+			Status: ReleaseStatusSkipped,
+			Error:  Locked,
 		}
 	}
 	return ControllerResult{}


### PR DESCRIPTION
Version 1.5.0 of the `flux` package doesn't support colons in the service ID/resource ID regex.

This means as soon there is a resource that has a colon in its actual name (e.g. default:clusterrolebinding/custom-metrics:system:auth-delegator) Fluxcloud will fail to parse the FluxEvent and just returns without triggering a webhook/Slack message.

This PR updates Flux to 1.6.0 where support for colons in the resource ID regexp was added.