### PR TITLE
Make fluxcloud port configurable to fix #16

### DIFF
--- a/cmd/fluxcloud.go
+++ b/cmd/fluxcloud.go
@@ -43,5 +43,5 @@ func main() {
 
 	apis.HandleWebsocket(apiConfig)
 	apis.HandleV6(apiConfig)
-	log.Fatal(apiConfig.Listen(":3031"))
+	log.Fatal(apiConfig.Listen(config.Optional("listen_address", ":3031")))
 }

--- a/examples/flux-deployment-sidecar.yaml
+++ b/examples/flux-deployment-sidecar.yaml
@@ -55,12 +55,12 @@ spec:
         # replace (at least) the following URL
         - --git-url=git@github.com:weaveworks/flux-example
         - --git-branch=master
-        - --connect=ws://127.0.0.1:3031
+        - --connect=ws://127.0.0.1:3032
       - name: fluxcloud
         image: justinbarrick/fluxcloud:v0.2.11
         imagePullPolicy: Always
         ports:
-        - containerPort: 3031
+        - containerPort: 3032
         env:
         # Set these environment variables:
         - name: SLACK_URL
@@ -76,3 +76,5 @@ spec:
           value: ":heart:"
         - name: GITHUB_URL
           value: "https://github.com/justinbarrick/fluxcloud/"
+        - name: LISTEN_ADDRESS
+          value: ":3032"

--- a/examples/fluxcloud.yaml
+++ b/examples/fluxcloud.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - protocol: TCP
     port: 80
-    targetPort: 3031
+    targetPort: 3032
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -29,7 +29,7 @@ spec:
         image: justinbarrick/fluxcloud:v0.2.11
         imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 3031
+        - containerPort: 3032
         env:
         - name: SLACK_URL
           value: "https://hooks.slack.com/services/WEBHOOK_URL"
@@ -44,3 +44,5 @@ spec:
           value: ":heart:"
         - name: GITHUB_URL
           value: "https://github.com/justinbarrick/fluxcloud/"
+        - name: LISTEN_ADDRESS
+          value: ":3032"

--- a/tests/fluxcloud.yaml
+++ b/tests/fluxcloud.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - protocol: TCP
     port: 80
-    targetPort: 3031
+    targetPort: 3032
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -29,7 +29,7 @@ spec:
         image: justinbarrick/fluxcloud:latest
         imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 3031
+        - containerPort: 3032
         env:
         - name: SLACK_URL
           value: "https://hooks.slack.com/services/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"
@@ -41,3 +41,5 @@ spec:
           value: ":weave:"
         - name: GITHUB_URL
           value: "https://github.com/justinbarrick/fluxcloud/"
+        - name: LISTEN_ADDRESS
+          value: ":3032"


### PR DESCRIPTION
By default, we will still use port 3031 to prevent breaking users that update fluxcloud
with Flux, since their services will all still point at 3031 we can't change the default
in the image.

We make the port configurable by the LISTEN_ADDRESS configuration option and set all
default configurations to 3032 to avoid a conflict when configuring Flux with the
recommended metrics port of 3031.