### PR TITLE
Add Slack token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Set the following environment variables in your chosen deployment:
 
 * `SLACK_URL`: the Slack [webhook URL](https://api.slack.com/incoming-webhooks) to use.
 * `SLACK_USERNAME`: the Slack username to use when sending messages.
+* `SLACK_TOKEN` (optional): legacy Slack API token to use.
 * `SLACK_CHANNEL`: the Slack channel to send messages to.
 * `SLACK_ICON_EMOJI`: the Slack emoji to use as the icon.
 * `MSTEAMS_URL`: the Microsoft Teams [webhook URL](https://docs.microsoft.com/en-us/outlook/actionable-messages/send-via-connectors#sending-actionable-messages-via-office-365-connectors) to use

--- a/examples/flux-deployment-sidecar.yaml
+++ b/examples/flux-deployment-sidecar.yaml
@@ -73,6 +73,12 @@ spec:
         # Or configure multiple channels
         # (comma separated <channel>=<namespace>) string:
         #  value: "#kubernetes=*,#team=team"
+        # Optional: legacy Slack API token
+        # - name: SLACK_TOKEN
+        #   valueFrom:
+        #     secretKeyRef:
+        #       key: token
+        #       name: slack-token
         - name: SLACK_USERNAME
           value: Flux Deployer
         - name: SLACK_ICON_EMOJI

--- a/examples/fluxcloud.yaml
+++ b/examples/fluxcloud.yaml
@@ -38,6 +38,12 @@ spec:
         # Or configure multiple channels
         # (comma separated <channel>=<namespace>) string:
         #  value: "#kubernetes=*,#team=team"
+        # Optional: legacy Slack API token
+        # - name: SLACK_TOKEN
+        #   valueFrom:
+        #     secretKeyRef:
+        #       key: token
+        #       name: slack-token
         - name: SLACK_USERNAME
           value: Flux Deployer
         - name: SLACK_ICON_EMOJI

--- a/pkg/exporters/slack.go
+++ b/pkg/exporters/slack.go
@@ -18,6 +18,7 @@ import (
 type Slack struct {
 	Url       string
 	Username  string
+	Token     string
 	Channels  []SlackChannel
 	IconEmoji string
 }
@@ -61,6 +62,7 @@ func NewSlack(config config.Config) (*Slack, error) {
 	s.parseSlackChannelConfig(channels)
 	log.Println(s.Channels)
 
+	s.Token = config.Optional("slack_token", "")
 	s.Username = config.Optional("slack_username", "Flux Deployer")
 	s.IconEmoji = config.Optional("slack_icon_emoji", ":star-struck:")
 
@@ -82,6 +84,11 @@ func (s *Slack) Send(c context.Context, client *http.Client, message msg.Message
 
 		req, _ := http.NewRequest("POST", s.Url, b)
 		req.Header.Set("Content-Type", "application/json")
+
+		if s.Token != "" {
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", s.Token))
+		}
+
 		req = req.WithContext(c)
 
 		res, err := client.Do(req)


### PR DESCRIPTION
Adds support for legacy Slack API tokens. Tokens are configured
via an environment variable `SLACK_TOKEN`. When specified,
an `Authorization: Bearer <token>` header is added to the
Slack webhook `POST`.