### PR TITLE
Updated example docker version

### DIFF
--- a/examples/fluxcloud.yaml
+++ b/examples/fluxcloud.yaml
@@ -31,7 +31,7 @@ spec:
         runAsUser: 999
       containers:
       - name: fluxcloud
-        image: justinbarrick/fluxcloud:v0.3.6
+        image: justinbarrick/fluxcloud:master-d8881c8
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3032
@@ -53,6 +53,11 @@ spec:
           value: Flux Deployer
         - name: SLACK_ICON_EMOJI
           value: ":heart:"
+        # Optional: use these variables to send notifications to msteams
+        # - name: EXPORTER_TYPE
+        #   value: msteams
+        # - name: MSTEAMS_URL
+        #   value: "https://outlook.office.com/webhook/WEBHOOK_URL"
         - name: GITHUB_URL
           value: "https://github.com/justinbarrick/fluxcloud/"
         - name: LISTEN_ADDRESS


### PR DESCRIPTION
I had to use a newer docker image version in order to get the msteams configuration to work.

I am not sure if the docker tag `master-d8881c8` is the desired tag, but it was the latest tag that I saw for branch master.