### PR TITLE
Fixed casing error on 'exporter_type'

### DIFF
--- a/cmd/fluxcloud.go
+++ b/cmd/fluxcloud.go
@@ -11,7 +11,7 @@ import (
 )
 
 func initExporter(config config.Config) (exporter []exporters.Exporter) {
-	exporterType := config.Optional("Exporter_type", "slack")
+	exporterType := config.Optional("exporter_type", "slack")
 
 	exporterTypes := strings.Split(exporterType, ",")
 


### PR DESCRIPTION
Fixed casing error on `exporter_type` preventing setting any other value than `slack`.

Earlier `EXPORTER_TYPE='slack,webhook'` did not work. Now it does. 