### PR TITLE
Add support for slack mrkdwn formatting

### DIFF
--- a/pkg/exporters/slack.go
+++ b/pkg/exporters/slack.go
@@ -33,10 +33,11 @@ type SlackMessage struct {
 
 // Represents a section of a slack message that is sent to the API
 type SlackAttachment struct {
-	Color     string `json:"color"`
-	Title     string `json:"title"`
-	TitleLink string `json:"title_link"`
-	Text      string `json:"text"`
+	Color      string   `json:"color"`
+	Title      string   `json:"title"`
+	TitleLink  string   `json:"title_link"`
+	Text       string   `json:"text"`
+	MarkdownIn []string `json:"mrkdwn_in"`
 }
 
 // Represents a slack channel and the Kubernetes namespace linked to it
@@ -127,10 +128,11 @@ func (s *Slack) NewSlackMessage(message msg.Message) []SlackMessage {
 			Username:  s.Username,
 			Attachments: []SlackAttachment{
 				SlackAttachment{
-					Color:     "#4286f4",
-					TitleLink: message.TitleLink,
-					Title:     message.Title,
-					Text:      message.Body,
+					Color:      "#4286f4",
+					TitleLink:  message.TitleLink,
+					Title:      message.Title,
+					Text:       message.Body,
+					MarkdownIn: []string{"text"},
 				},
 			},
 		}


### PR DESCRIPTION
Allow end users to have a `BODY_TEMPLATE` to contain slack's markup formatting as per their [docs](https://api.slack.com/reference/messaging/attachments).

This is enabled by default however if there are concerns about it we can add a config flag to make it opt in?

Example use case is using code blocks in the notifications:
```yaml
        env:
        - name: BODY_TEMPLATE
          value: |
            Event: {{ .EventString }}
            {{ if and (ne .EventType "commit") (gt (len .Commits) 0) }}
            {{ range .Commits }}
            * {{ call $.FormatLink (print $.VCSLink "/commits/" .Revision) (truncate .Revision 7) }}: `{{ .Message }}`
            {{end}}{{end}}
            {{ if (gt (len .EventServiceIDs) 0) }}Resources updated:
            ```{{ range .EventServiceIDs }}
            * {{ . }}
            {{ end }}```{{ end }}
            {{ if gt (len .Errors) 0 }}Errors:
            ```{{ range .Errors }}
            Resource {{ .ID }}, file: {{ .Path }}:

            > {{ .Error }}
            {{ end }}```{{ end }}
```