### PR TITLE
Add the ONLY_SEND_ERRORS option, to only forward Flux errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Set the following environment variables in your chosen deployment:
 * `WEBHOOK_URL`: if the exporter is "webhook", then the URL to use for the webhook.
 * `EXPORTER_TYPE` (optional): The types of exporter to use in comma delimited form. (Ex: `slack,webhook`) (Choices: slack, msteams, webhook, Default: slack)
 * `JAEGER_ENDPOINT` (optional): endpoint to report Jaeger traces to.
+* `ONLY_SEND_ERRORS` (optional): if set to "1", only events indicating an error will be sent.
 
 And then apply the configuration:
 

--- a/pkg/apis/v6.go
+++ b/pkg/apis/v6.go
@@ -24,6 +24,11 @@ func HandleV6(config APIConfig) (err error) {
 			return
 		}
 
+		if config.Config.Optional("ONLY_SEND_ERRORS", "0") == "1" && !utils.IsErrorEvent(event) {
+			w.WriteHeader(200)
+			return
+		}
+
 		var sendError bool
 		for _, exporter := range config.Exporter {
 			message := config.Formatter.FormatEvent(event, exporter)

--- a/pkg/apis/v6_test.go
+++ b/pkg/apis/v6_test.go
@@ -24,6 +24,7 @@ func TestHandleV6(t *testing.T) {
 		Server:    http.NewServeMux(),
 		Exporter:  []exporters.Exporter{fakeExporter},
 		Formatter: formatter,
+		Config:    config,
 	}
 
 	HandleV6(apiConfig)

--- a/pkg/utils/test/utils_test.go
+++ b/pkg/utils/test/utils_test.go
@@ -1,6 +1,7 @@
 package test_utils
 
 import (
+	"github.com/justinbarrick/fluxcloud/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	fluxevent "github.com/weaveworks/flux/event"
 	"testing"
@@ -54,4 +55,12 @@ func TestParseFluxEventSyncError(t *testing.T) {
 	assert.Equal(t, "create invalid resource", commit.Message)
 	assert.Equal(t, true, metadata.Includes["other"])
 	assert.Equal(t, "running kubectl: The PersistentVolumeClaim \"test\" is invalid: spec: Forbidden: field is immutable after creation", metadata.Errors[0].Error)
+}
+
+func TestIsErrorEvent(t *testing.T) {
+	assert.Equal(t, utils.IsErrorEvent(NewFluxSyncEvent()), false)
+	assert.Equal(t, utils.IsErrorEvent(NewFluxSyncErrorEvent()), true)
+	assert.Equal(t, utils.IsErrorEvent(NewFluxCommitEvent()), false)
+	assert.Equal(t, utils.IsErrorEvent(NewFluxAutoReleaseEvent()), false)
+	assert.Equal(t, utils.IsErrorEvent(NewFluxUpdatePolicyEvent()), false)
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -12,3 +12,22 @@ func ParseFluxEvent(reader io.Reader) (event fluxevent.Event, err error) {
 	err = json.NewDecoder(reader).Decode(&event)
 	return
 }
+
+func IsErrorEvent(event fluxevent.Event) bool {
+	switch event.Type {
+	case fluxevent.EventRelease:
+		metadata := event.Metadata.(*fluxevent.ReleaseEventMetadata)
+		return len(metadata.Result.Error()) > 0
+	case fluxevent.EventAutoRelease:
+		metadata := event.Metadata.(*fluxevent.AutoReleaseEventMetadata)
+		return len(metadata.Result.Error()) > 0
+	case fluxevent.EventCommit:
+		metadata := event.Metadata.(*fluxevent.CommitEventMetadata)
+		return len(metadata.Result.Error()) > 0
+	case fluxevent.EventSync:
+		metadata := event.Metadata.(*fluxevent.SyncEventMetadata)
+		return len(metadata.Errors) > 0
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Closes #43 

Please let me know if there's something missing in this PR!